### PR TITLE
Read string value for Statement Action and Resource as a 1-length array

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@ Supports different principals.
 
 ## Limitations
 
-The library only supports the canonical form of IAM Policy JSON documents, i.e.
-everywhere a string or an array can be passed, an array is expected.
+The library now supports a single string as `Action` and `Resource` value, though it does not yet support this for `Principal` and `Condition` key values.
+
+For `Principal` and `Condition` it still expects the canonical form of an IAM Policy JSON document, i.e. everywhere a string or an array can be passed, an array is expected.
 
 ```json
 {
@@ -154,8 +155,8 @@ everywhere a string or an array can be passed, an array is expected.
       "Principal": {
         "AWS": ["arn:aws:iam::123456789012:user/user-name"]
       },
-      "Action": ["ec2:Describe*"],
-      "Resource": ["*"],
+      "Action": "ec2:Describe*",
+      "Resource": "*",
       "Condition": {
         "StringEquals": {
           "kms:CallerAccount": ["123456789012"]

--- a/src/statement/deserialiser.ts
+++ b/src/statement/deserialiser.ts
@@ -13,17 +13,20 @@ export class StatementJSONDeserialiser {
       conditions: ConditionJSONDeserialiser.fromJSON(obj.Condition),
     });
 
-    function parseArray(obj: any): [] {
+    function parseArray(obj: any): string[] {
       if (obj === undefined) {
         return [];
       }
+      if (typeof obj === 'string') {
+        return [obj];
+      }
       if (Array.isArray(obj)) {
         if (isArrayOfStrings(obj)) {
-          return obj as [];
+          return obj;
         }
         throw new Error('Unsupported type: expecting an array of strings');
       }
-      throw new Error('Unsupported type: expecting an array');
+      throw new Error('Unsupported type: expecting an array or a string');
     }
 
     function isArrayOfStrings(obj: any[]) {

--- a/tests/statement/deserialiser.spec.ts
+++ b/tests/statement/deserialiser.spec.ts
@@ -66,5 +66,18 @@ describe('#StatementDeserialiser', function() {
             .with.property('message', 'Unsupported type: expecting an array or a string');
       });
     });
+
+    describe('and its value is a string', function() {
+      const json = {
+        Resource: 'resource',
+      };
+      it('should return a Statement with resources', function() {
+        const actual = StatementJSONDeserialiser.fromJSON(json);
+        const expected = new Statement({
+          resources: ['resource'],
+        });
+        expect(actual).to.deep.equal(expected);
+      });
+    });
   });
 });

--- a/tests/statement/deserialiser.spec.ts
+++ b/tests/statement/deserialiser.spec.ts
@@ -18,7 +18,7 @@ describe('#StatementDeserialiser', function() {
       };
       it('should throw an Error', function() {
         expect(() => StatementJSONDeserialiser.fromJSON(json)).to.throw(Error)
-            .with.property('message', 'Unsupported type: expecting an array');
+            .with.property('message', 'Unsupported type: expecting an array or a string');
       });
     });
 

--- a/tests/statement/deserialiser.spec.ts
+++ b/tests/statement/deserialiser.spec.ts
@@ -60,7 +60,7 @@ describe('#StatementDeserialiser', function() {
       };
       it('should throw an Error', function() {
         expect(() => StatementJSONDeserialiser.fromJSON(json)).to.throw(Error)
-            .with.property('message', 'Unsupported type: expecting an array');
+            .with.property('message', 'Unsupported type: expecting an array or a string');
       });
     });
   });

--- a/tests/statement/deserialiser.spec.ts
+++ b/tests/statement/deserialiser.spec.ts
@@ -26,9 +26,12 @@ describe('#StatementDeserialiser', function() {
       const json = {
         Action: 'action',
       };
-      it('should throw an Error', function() {
-        expect(() => StatementJSONDeserialiser.fromJSON(json)).to.throw(Error)
-            .with.property('message', 'Unsupported type: expecting an array');
+      it('should return a Statement with actions', function() {
+        const actual = StatementJSONDeserialiser.fromJSON(json);
+        const expected = new Statement({
+          actions: ['action'],
+        });
+        expect(actual).to.deep.equal(expected);
       });
     });
 


### PR DESCRIPTION
It's valid (and expected) for Resource to be a plain string instead of an array of strings. This is shown clearly (but not explicitly said) in the IAM docs:

* https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
* https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html

This change reads any bare string as a 1-length array to keep things normalized.

Fixes #7 