### PR TITLE
Export `WildcardPrincipal`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,5 @@ export * from './principals/service';
 export * from './principals/account';
 export * from './principals/root-account';
 export * from './principals/federated';
+export * from './principals/wildcard';
 export * from './condition/condition';

--- a/tests/principals/wildcard.spec.ts
+++ b/tests/principals/wildcard.spec.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {WildcardPrincipal} from '../../src/principals/wildcard';
+import {WildcardPrincipal} from '../../src';
 
 describe('#WildcardPrincipal', function() {
   describe('#toJSON', function() {


### PR DESCRIPTION
`WildcardPrincipal` was added in #22, but it's not actually exported.