### PR TITLE
Drop engines Node requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
   ],
   "author": "ThinkingLabs",
   "license": "MIT",
-  "engineStrict": true,
-  "engines": {
-    "node": "^16"
-  },
   "volta": {
     "node": "16.14.1"
   },


### PR DESCRIPTION
I don't think we need to be strict about the version of Node that consumers of this library use. There's not much here that would break on different versions of Node.

Fixes #27